### PR TITLE
Migrate to Bitcoin 0.21.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM debian:buster@sha256:41f76363fd83982e14f7644486e1fb04812b3894aa4e396137c3435eaf05de88
+FROM debian:bullseye
 COPY /buster_deps.sh /
 RUN /buster_deps.sh

--- a/buster_deps.sh
+++ b/buster_deps.sh
@@ -7,12 +7,12 @@ sha256_file=8381c440fe61fcbb01e209211ac01b519cd6adf51ab1c2281d5daad6ca4c8c8c
 
 apt-get -yqq update &> /dev/null
 apt-get -yqq upgrade &> /dev/null
-apt-get -yqq install python curl build-essential libtool autotools-dev automake pkg-config bsdmainutils unzip git &> /dev/null
+apt-get -yqq install python3 python-is-python3 curl ca-certificates build-essential libtool autotools-dev automake pkg-config bsdmainutils unzip git &> /dev/null
 
 mkdir -p /opt
 
 cd /opt && curl -sSO https://dl.google.com/android/repository/${NDK_FILENAME} &> /dev/null
-echo "${sha256_file}  ${NDK_FILENAME}" | shasum -a 256 --check
+echo "${sha256_file}  ${NDK_FILENAME}" | sha256sum -c -
 unzip -qq ${NDK_FILENAME} &> /dev/null
 rm ${NDK_FILENAME}
 

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,7 @@ build_repo() {
     done
 }
 
-build_repo https://github.com/bitcoin/bitcoin.git 1bc9988993ee84bc814e5a7f33cc90f670a19f6a bitcoin bitcoin --disable-man
+build_repo https://github.com/bitcoin/bitcoin.git f49250e32be946ee4ed0f455772a4480453f0fdd bitcoin bitcoin --disable-man
 build_repo https://github.com/bitcoinknots/bitcoin.git f8d8a318e8ff7fb396b3102a532c790a7430ed81 bitcoin bitcoin --disable-man
 build_repo https://github.com/elementsproject/elements.git 928727ad6e626ac6ab45bb30867bd3519bc8ab25 elements liquid --enable-liquid
 


### PR DESCRIPTION
I've begun work on updating this project to Bitcoin 0.21.1, with several remaining questions:

- [ ] What is the desired behavior for the Dockerfile hash check?
- [ ] What is the role of `ca-certificates` in the dependency script?
- [ ] What are the appropriate versions of Knots and Elements to match?

I will happily rebase, squash, whatever is necessary to build a new version of ABCore.  Please advise.